### PR TITLE
Convert package to use abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package will add support for flutter features which is out of the scope of 
 ## Getting started
 
 ## Usage
-Add dependency in pubspec.yml
+Add dependency in pubspec.yml, path_provider dependency is also needed
 
 ```yml
 dependencies:
@@ -17,15 +17,15 @@ dependencies:
     sdk: flutter
     
   network_tools_flutter: ^1.0.4
+  path_provider: ^2.1.2
 ```
 
-Import package in your project
+
+
+And initialize the pacakge in the main function
+
 ```dart
-import 'package:network_tools_flutter/network_tools_flutter.dart';
+ await configureNetworkToolsFlutter((await getApplicationDocumentsDirectory()).path);
 ```
 
-Use HostScannerFlutter and PortScannerFlutter for your flutter projects. See example directory for illustration.
-
-## Additional information
-
-You can use same APIs but need to import from network_tools_flutter. All APIs from network_tools are automatically imported by network_tools_flutter. So just import network_tools_flutter in your flutter app. 
+From here please follow the documentation of [network_tools](https://pub.dev/packages/network_tools) as they are the same. 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -22,7 +22,6 @@ analyzer:
     - "**/*.pbjson.dart"
     - "**/*.gr.dart"
     - "**/*.md"
-    - "example/**"
 
 linter:
   rules:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,7 +7,8 @@ import 'package:path_provider/path_provider.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final appDocDirectory = await getApplicationDocumentsDirectory();
-  await configureNetworkTools(appDocDirectory.path, enableDebugging: true);
+  await configureNetworkToolsFlutter(appDocDirectory.path,
+      enableDebugging: true);
   runApp(const MyApp());
 }
 

--- a/example/lib/pages/pingable_devices.dart
+++ b/example/lib/pages/pingable_devices.dart
@@ -19,11 +19,14 @@ class _PingableDevicesState extends State<PingableDevices> {
       if (netInt == null) {
         return;
       }
-      HostScannerFlutter.getAllPingableDevices(netInt.networkId).listen((host) {
+      HostScannerService.instance
+          .getAllPingableDevices(netInt.networkId)
+          .listen((host) {
         setState(() {
           activeHosts.add(host);
         });
       }).onError((e) {
+        // ignore: avoid_print
         print('Error $e');
       });
     });

--- a/example/lib/pages/port_scanner_page.dart
+++ b/example/lib/pages/port_scanner_page.dart
@@ -21,11 +21,14 @@ class _PortScannerPageState extends State<PortScannerPage> {
       }
       String subnet =
           netInt.ipAddress.substring(0, netInt.ipAddress.lastIndexOf('.'));
-      HostScanner.scanDevicesForSinglePort(subnet, 53).listen((host) {
+      HostScannerService.instance
+          .scanDevicesForSinglePort(subnet, 53)
+          .listen((host) {
         setState(() {
           activeHosts.add(host);
         });
       }).onError((e) {
+        // ignore: avoid_print
         print('Error $e');
       });
     });

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -33,14 +33,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -69,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: csv
-      sha256: "016b31a51a913744a0a1655c74ff13c9379e1200e246a03d96c81c5d9ed297b5"
+      sha256: "63ed2871dd6471193dffc52c0e6c76fb86269c00244d244297abbb355c84a86e"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "5.1.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -85,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: dart_ping
-      sha256: dd3a93d9b986565cb2fadd0c9277cf9880298634ccc9588e353e63c6f736a386
+      sha256: "2f5418d0a5c64e53486caaac78677b25725b1e13c33c5be834ce874ea18bd24f"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.0.1"
   dart_ping_ios:
     dependency: transitive
     description:
@@ -155,22 +147,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  get_it:
-    dependency: transitive
-    description:
-      name: get_it
-      sha256: f79870884de16d689cf9a7d15eedf31ed61d750e813c538a6efb92660fea83c3
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.6.4"
   http:
     dependency: transitive
     description:
       name: http
-      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
+      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   http_parser:
     dependency: transitive
     description:
@@ -179,14 +163,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  injectable:
-    dependency: transitive
-    description:
-      name: injectable
-      sha256: "5217c45fec809286a7b1b4fbcbd70aab1662bf18d9eb207490df421323f7883f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.0"
   intl:
     dependency: transitive
     description:
@@ -247,25 +223,24 @@ packages:
     dependency: transitive
     description:
       name: multicast_dns
-      sha256: f4fd1c3365171fac5160afcb1a283001d3413dee5fd41c61d80888952d609379
+      sha256: "316cc47a958d4bd3c67bd238fe8b44fdfb6133bad89cb191c0c3bd3edb14e296"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2+4"
+    version: "0.3.2+6"
   network_tools:
     dependency: transitive
     description:
-      name: network_tools
-      sha256: "84cd355e2d9db58456a05b7ebd4021fcbe42241043b7e6157bff2a0853054dd4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.1"
+      path: "../../network_tools"
+      relative: true
+    source: path
+    version: "4.0.4"
   network_tools_flutter:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.4"
+    version: "1.0.5"
   path:
     dependency: transitive
     description:
@@ -342,10 +317,10 @@ packages:
     dependency: transitive
     description:
       name: process_run
-      sha256: ceacfac6d566a36c895d64edc7e429efb2d6b6303b5e28d5c13bc59fe6e8974e
+      sha256: cad2c57a34f8313a4182e34e31e0b2f12972eef3d0930cdc7ab3240bb8cad380
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.1"
+    version: "0.14.1+3"
   pub_semver:
     dependency: transitive
     description:
@@ -488,5 +463,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.2.0 <4.0.0"
   flutter: ">=3.7.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -179,6 +179,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -199,26 +223,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   multicast_dns:
     dependency: transitive
     description:
@@ -230,10 +254,11 @@ packages:
   network_tools:
     dependency: transitive
     description:
-      path: "../../network_tools"
-      relative: true
-    source: path
-    version: "4.0.4"
+      name: network_tools
+      sha256: c7543a957006047d4b6e7442c2cc0f592a1dd6572a6c1024301bc11dc53d45de
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   network_tools_flutter:
     dependency: "direct main"
     description:
@@ -245,10 +270,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -430,6 +455,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
   web:
     dependency: transitive
     description:

--- a/lib/network_tools_flutter.dart
+++ b/lib/network_tools_flutter.dart
@@ -1,5 +1,4 @@
 library network_tools_flutter;
 
-export 'src/host_scanner_flutter.dart';
-export 'src/port_scanner_flutter.dart';
 export 'package:network_tools/network_tools.dart';
+export 'package:network_tools_flutter/src/configure_flutter.dart';

--- a/lib/src/configure_flutter.dart
+++ b/lib/src/configure_flutter.dart
@@ -1,0 +1,39 @@
+import 'package:logging/logging.dart';
+import 'package:network_tools/network_tools.dart' as pacakges_page;
+// ignore: implementation_imports
+import 'package:network_tools/src/network_tools_utils.dart';
+// ignore: implementation_imports
+import 'package:network_tools/src/services/arp_service.dart';
+// ignore: implementation_imports
+import 'package:network_tools/src/services/impls/arp_service_sembast_impl.dart';
+import 'package:network_tools_flutter/src/services_impls/host_scanner_service_flutter_impl.dart';
+import 'package:network_tools_flutter/src/services_impls/port_scanner_service_flutter_impl.dart';
+
+Future<void> configureNetworkToolsFlutter(
+  String dbDirectory, {
+  bool enableDebugging = false,
+}) async {
+  pacakges_page.enableDebugging = enableDebugging;
+  pacakges_page.dbDirectory = dbDirectory;
+
+  if (pacakges_page.enableDebugging) {
+    Logger.root.level = Level.FINE;
+    Logger.root.onRecord.listen((record) {
+      if (record.loggerName == log.name) {
+        // ignore: avoid_print
+        print(
+          '${record.time.toLocal()}: ${record.level.name}: ${record.loggerName}: ${record.message}',
+        );
+      }
+    });
+  }
+
+  /// Setting dart native classes implementations
+  ARPServiceSembastImpl();
+  HostScannerServiceFlutterImpl();
+  PortScannerServiceFlutterImpel();
+
+  final arpService = await ARPService.instance.open();
+  await arpService.buildTable();
+  await pacakges_page.VendorTable.createVendorTableMap();
+}

--- a/lib/src/configure_flutter.dart
+++ b/lib/src/configure_flutter.dart
@@ -31,7 +31,7 @@ Future<void> configureNetworkToolsFlutter(
   /// Setting dart native classes implementations
   ARPServiceSembastImpl();
   HostScannerServiceFlutterImpl();
-  PortScannerServiceFlutterImpel();
+  PortScannerServiceFlutterImpl();
 
   final arpService = await ARPService.instance.open();
   await arpService.buildTable();

--- a/lib/src/services_impls/host_scanner_service_flutter_impl.dart
+++ b/lib/src/services_impls/host_scanner_service_flutter_impl.dart
@@ -16,13 +16,14 @@ class HostScannerServiceFlutterImpl extends HostScannerServiceImpl {
   /// Set maxHost to higher value if you are not getting results.
   /// It won't firstHostId again unless previous scan is completed due to heavy
   /// resource consumption.
-  /// [resultsInAddressAscendingOrder] = false will return results faster but not in
+  /// [resultsInAddressAscendingOrder] = false will return results faster but not in order
   @override
   Stream<ActiveHost> getAllPingableDevices(
     String subnet, {
     int firstHostId = HostScannerService.defaultFirstHostId,
     int lastHostId = HostScannerService.defaultLastHostId,
     int timeoutInSeconds = 1,
+    List<int> hostIds = const [],
     ProgressCallback? progressCallback,
     bool resultsInAddressAscendingOrder = true,
   }) async* {
@@ -57,7 +58,8 @@ class HostScannerServiceFlutterImpl extends HostScannerServiceImpl {
             timeoutInSeconds.toString(),
             resultsInAddressAscendingOrder.toString(),
             dbDirectory,
-            enableDebugging.toString()
+            enableDebugging.toString(),
+            hostIds.join(','),
           ]);
         } else if (message is List<String>) {
           progressCallback
@@ -93,6 +95,11 @@ class HostScannerServiceFlutterImpl extends HostScannerServiceImpl {
       final bool resultsInAddressAscendingOrder = message[4] == "true";
       final String dbDirectory = message[5];
       final bool enableDebugging = message[6] == "true";
+      final List<int> hostIds = message[7]
+          .split(',')
+          .where((e) => e.isNotEmpty)
+          .map(int.parse)
+          .toList();
       await configureNetworkTools(dbDirectory,
           enableDebugging: enableDebugging);
 
@@ -103,6 +110,7 @@ class HostScannerServiceFlutterImpl extends HostScannerServiceImpl {
         subnetIsolate,
         firstHostId: firstSubnetIsolate,
         lastHostId: lastSubnetIsolate,
+        hostIds: hostIds,
         timeoutInSeconds: timeoutInSeconds,
         resultsInAddressAscendingOrder: resultsInAddressAscendingOrder,
       );

--- a/lib/src/services_impls/host_scanner_service_flutter_impl.dart
+++ b/lib/src/services_impls/host_scanner_service_flutter_impl.dart
@@ -7,25 +7,28 @@ import 'package:dart_ping_ios/dart_ping_ios.dart';
 import 'package:flutter_isolate/flutter_isolate.dart';
 import 'package:network_tools/network_tools.dart';
 import 'package:universal_io/io.dart';
+// ignore: implementation_imports
+import 'package:network_tools/src/services/impls/host_scanner_service_impl.dart';
 
 /// Scans for all hosts in a subnet.
-class HostScannerFlutter {
+class HostScannerServiceFlutterImpl extends HostScannerServiceImpl {
   /// Scans for all hosts in a particular subnet (e.g., 192.168.1.0/24)
   /// Set maxHost to higher value if you are not getting results.
   /// It won't firstHostId again unless previous scan is completed due to heavy
   /// resource consumption.
   /// [resultsInAddressAscendingOrder] = false will return results faster but not in
-  static Stream<ActiveHost> getAllPingableDevices(
+  @override
+  Stream<ActiveHost> getAllPingableDevices(
     String subnet, {
-    int firstHostId = HostScanner.defaultFirstHostId,
-    int lastHostId = HostScanner.defaultLastHostId,
+    int firstHostId = HostScannerService.defaultFirstHostId,
+    int lastHostId = HostScannerService.defaultLastHostId,
     int timeoutInSeconds = 1,
     ProgressCallback? progressCallback,
     bool resultsInAddressAscendingOrder = true,
   }) async* {
     const int scanRangeForIsolate = 51;
-    final int lastValidSubnet = HostScanner.validateAndGetLastValidSubnet(
-        subnet, firstHostId, lastHostId);
+    final int lastValidSubnet =
+        super.validateAndGetLastValidSubnet(subnet, firstHostId, lastHostId);
 
     for (int i = firstHostId;
         i <= lastValidSubnet;
@@ -37,10 +40,12 @@ class HostScannerFlutter {
       if (Platform.isAndroid || Platform.isIOS) {
         // Flutter isolate is not implemented for other platforms than these two
         isolate = await FlutterIsolate.spawn(
-            HostScannerFlutter._startSearchingDevices, receivePort.sendPort);
+            HostScannerServiceFlutterImpl._startSearchingDevices,
+            receivePort.sendPort);
       } else {
         isolate = await Isolate.spawn(
-            HostScannerFlutter._startSearchingDevices, receivePort.sendPort);
+            HostScannerServiceFlutterImpl._startSearchingDevices,
+            receivePort.sendPort);
       }
 
       await for (final message in receivePort) {
@@ -94,7 +99,7 @@ class HostScannerFlutter {
       /// Will contain all the hosts that got discovered in the network, will
       /// be use inorder to cancel on dispose of the page.
       final Stream<SendableActiveHost> hostsDiscoveredInNetwork =
-          HostScanner.getAllSendablePingableDevices(
+          HostScannerService.instance.getAllSendablePingableDevices(
         subnetIsolate,
         firstHostId: firstSubnetIsolate,
         lastHostId: lastSubnetIsolate,

--- a/lib/src/services_impls/port_scanner_service_flutter_impl.dart
+++ b/lib/src/services_impls/port_scanner_service_flutter_impl.dart
@@ -7,7 +7,7 @@ import 'package:network_tools/network_tools.dart';
 import 'package:network_tools/src/services/impls/port_scanner_service_impl.dart';
 
 /// Flutter flavor of PortScannerService.instance, only use if your project is based of flutter.
-class PortScannerServiceFlutterImpel extends PortScannerServiceImpl {
+class PortScannerServiceFlutterImpl extends PortScannerServiceImpl {
   /// Checks if the single [port] is open or not for the [target].
   @override
   Future<ActiveHost?> isOpen(

--- a/lib/src/services_impls/port_scanner_service_flutter_impl.dart
+++ b/lib/src/services_impls/port_scanner_service_flutter_impl.dart
@@ -3,11 +3,14 @@ import 'dart:io';
 
 import 'package:dart_ping_ios/dart_ping_ios.dart';
 import 'package:network_tools/network_tools.dart';
+// ignore: implementation_imports
+import 'package:network_tools/src/services/impls/port_scanner_service_impl.dart';
 
-/// Flutter flavor of PortScanner, only use if your project is based of flutter.
-class PortScannerFlutter {
+/// Flutter flavor of PortScannerService.instance, only use if your project is based of flutter.
+class PortScannerServiceFlutterImpel extends PortScannerServiceImpl {
   /// Checks if the single [port] is open or not for the [target].
-  static Future<ActiveHost?> isOpen(
+  @override
+  Future<ActiveHost?> isOpen(
     String target,
     int port, {
     Duration timeout = const Duration(milliseconds: 2000),
@@ -15,7 +18,7 @@ class PortScannerFlutter {
     if (Platform.isIOS) {
       DartPingIOS.register();
     }
-    return PortScanner.isOpen(target, port, timeout: timeout);
+    return super.isOpen(target, port, timeout: timeout);
   }
 
   /// Scans ports only listed in [portList] for a [target]. Progress can be
@@ -23,9 +26,10 @@ class PortScannerFlutter {
   /// Tries connecting ports before until [timeout] reached.
   /// [resultsInAddressAscendingOrder] = false will return results faster but not in
   /// ascending order and without [progressCallback].
-  static Stream<ActiveHost> customDiscover(
+  @override
+  Stream<ActiveHost> customDiscover(
     String target, {
-    List<int> portList = PortScanner.commonPorts,
+    List<int> portList = PortScannerService.commonPorts,
     ProgressCallback? progressCallback,
     Duration timeout = const Duration(milliseconds: 2000),
     bool resultsInAddressAscendingOrder = true,
@@ -34,7 +38,7 @@ class PortScannerFlutter {
     if (Platform.isIOS) {
       DartPingIOS.register();
     }
-    return PortScanner.customDiscover(target,
+    return super.customDiscover(target,
         portList: portList,
         progressCallback: progressCallback,
         timeout: timeout,
@@ -45,10 +49,11 @@ class PortScannerFlutter {
   /// Scans port from [startPort] to [endPort] of [target]. Progress can be
   /// retrieved by [progressCallback]
   /// Tries connecting ports before until [timeout] reached.
-  static Stream<ActiveHost> scanPortsForSingleDevice(
+  @override
+  Stream<ActiveHost> scanPortsForSingleDevice(
     String target, {
-    int startPort = PortScanner.defaultEndPort,
-    int endPort = PortScanner.defaultEndPort,
+    int startPort = PortScannerService.defaultEndPort,
+    int endPort = PortScannerService.defaultEndPort,
     ProgressCallback? progressCallback,
     Duration timeout = const Duration(milliseconds: 2000),
     bool resultsInAddressAscendingOrder = true,
@@ -57,7 +62,7 @@ class PortScannerFlutter {
     if (Platform.isIOS) {
       DartPingIOS.register();
     }
-    return PortScanner.scanPortsForSingleDevice(target,
+    return super.scanPortsForSingleDevice(target,
         startPort: startPort,
         endPort: endPort,
         progressCallback: progressCallback,
@@ -66,7 +71,8 @@ class PortScannerFlutter {
         async: async);
   }
 
-  static Future<ActiveHost?> connectToPort({
+  @override
+  Future<ActiveHost?> connectToPort({
     required String address,
     required int port,
     required Duration timeout,
@@ -76,7 +82,7 @@ class PortScannerFlutter {
     if (Platform.isIOS) {
       DartPingIOS.register();
     }
-    return PortScanner.connectToPort(
+    return super.connectToPort(
         address: address,
         port: port,
         timeout: timeout,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,11 @@ dependencies:
   logging: ^1.2.0
   # Deal with internationalized/localized messages and more.
   intl: ^0.18.0
-  network_tools: ^4.0.3
+  # network_tools: ^4.0.3
+  network_tools: 
+    git:
+     url: "https://github.com/guyluz11/network_tools.git"
+     ref: "abstracting_services"
   path_provider: ^2.1.1
   universal_io: ^2.2.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,11 +39,7 @@ dependencies:
   logging: ^1.2.0
   # Deal with internationalized/localized messages and more.
   intl: ^0.18.0
-  # network_tools: ^4.0.3
-  network_tools: 
-    git:
-     url: "https://github.com/guyluz11/network_tools.git"
-     ref: "abstracting_services"
+  network_tools: ^5.0.0
   path_provider: ^2.1.1
   universal_io: ^2.2.0
 

--- a/test/host_scan_flutter_test.dart
+++ b/test/host_scan_flutter_test.dart
@@ -14,7 +14,7 @@ void main() {
   // Fetching interfaceIp and hostIp
   setUpAll(() async {
     HttpOverrides.global = FakeResponseHttpOverrides();
-    await configureNetworkTools('build');
+    await configureNetworkToolsFlutter('build');
     //open a port in shared way because of portscanner using same,
     //if passed false then two hosts come up in search and breaks test.
     server =
@@ -38,7 +38,7 @@ void main() {
     test('Running getAllPingableDevices emits tests', () async* {
       expectLater(
         //There should be at least one device pingable in network
-        HostScannerFlutter.getAllPingableDevices(
+        HostScannerService.instance.getAllPingableDevices(
           interfaceIp,
           firstHostId: firstHostId,
           lastHostId: lastHostId,
@@ -49,7 +49,7 @@ void main() {
     test('Running getAllPingableDevices emitsThrough tests', () async* {
       expectLater(
         //Should emit at least our own local machine when pinging all hosts.
-        HostScannerFlutter.getAllPingableDevices(
+        HostScannerService.instance.getAllPingableDevices(
           interfaceIp,
           firstHostId: firstHostId,
           lastHostId: lastHostId,

--- a/test/host_scan_flutter_test.dart
+++ b/test/host_scan_flutter_test.dart
@@ -59,28 +59,42 @@ void main() {
       );
     });
 
-    expectLater(
-      //There should be at least one device pingable in network when limiting to own hostId
-      HostScannerService.instance.getAllPingableDevices(
-        interfaceIp,
-        timeoutInSeconds: 3,
-        hostIds: [hostId],
-        firstHostId: firstHostId,
-        lastHostId: lastHostId,
-      ),
-      emits(isA<ActiveHost>()),
-    );
-    expectLater(
-      //There should be at least one device pingable in network when limiting to hostId other than own
-      HostScannerService.instance.getAllPingableDevices(
-        interfaceIp,
-        timeoutInSeconds: 3,
-        hostIds: [0],
-        firstHostId: firstHostId,
-        lastHostId: lastHostId,
-      ),
-      neverEmits(isA<ActiveHost>()),
-    );
+    test('Running getAllPingableDevices emits tests', () async* {
+      expectLater(
+        //There should be at least one device pingable in network
+        HostScannerService.instance.getAllPingableDevices(
+          interfaceIp,
+          firstHostId: firstHostId,
+          lastHostId: lastHostId,
+        ),
+        emits(isA<ActiveHost>()),
+      );
+    });
+
+    test('Running getAllPingableDevices limiting hostId tests', () async* {
+      expectLater(
+        //There should be at least one device pingable in network when limiting to own hostId
+        HostScannerService.instance.getAllPingableDevices(
+          interfaceIp,
+          timeoutInSeconds: 3,
+          hostIds: [hostId],
+          firstHostId: firstHostId,
+          lastHostId: lastHostId,
+        ),
+        emits(isA<ActiveHost>()),
+      );
+      expectLater(
+        //There should be at least one device pingable in network when limiting to hostId other than own
+        HostScannerService.instance.getAllPingableDevices(
+          interfaceIp,
+          timeoutInSeconds: 3,
+          hostIds: [0],
+          firstHostId: firstHostId,
+          lastHostId: lastHostId,
+        ),
+        neverEmits(isA<ActiveHost>()),
+      );
+    });
   });
 
   tearDownAll(() {

--- a/test/port_scan_flutter_test.dart
+++ b/test/port_scan_flutter_test.dart
@@ -13,16 +13,16 @@ void main() {
   // Fetching interfaceIp and hostIp
   setUpAll(() async {
     HttpOverrides.global = FakeResponseHttpOverrides();
-    await configureNetworkTools('build');
-    //open a port in shared way because of hostscanner using same,
+    await configureNetworkToolsFlutter('build');
+    //open a port in shared way because of HostScannerService.instance using same,
     //if passed false then two hosts come up in search and breaks test.
     server =
         await ServerSocket.bind(InternetAddress.anyIPv4, port, shared: true);
     port = server.port;
     final interface = await NetInterface.localInterface();
     if (interface != null) {
-      await for (final host
-          in HostScanner.scanDevicesForSinglePort(interface.networkId, port)) {
+      await for (final host in HostScannerService.instance
+          .scanDevicesForSinglePort(interface.networkId, port)) {
         hostsWithOpenPort.add(host);
       }
     }
@@ -33,7 +33,7 @@ void main() {
       for (final activeHost in hostsWithOpenPort) {
         final port = activeHost.openPorts.elementAt(0).port;
         expectLater(
-          PortScannerFlutter.scanPortsForSingleDevice(
+          PortScannerService.instance.scanPortsForSingleDevice(
             activeHost.address,
             startPort: port - 1,
             endPort: port + 1,
@@ -53,7 +53,7 @@ void main() {
       for (final activeHost in hostsWithOpenPort) {
         final port = activeHost.openPorts.elementAt(0).port;
         expectLater(
-          PortScannerFlutter.scanPortsForSingleDevice(
+          PortScannerService.instance.scanPortsForSingleDevice(
             activeHost.address,
             startPort: port - 1,
             endPort: port + 1,
@@ -73,7 +73,7 @@ void main() {
     test('Running connectToPort tests', () {
       for (final activeHost in hostsWithOpenPort) {
         expectLater(
-          PortScannerFlutter.connectToPort(
+          PortScannerService.instance.connectToPort(
             address: activeHost.address,
             port: port,
             timeout: const Duration(seconds: 5),
@@ -92,7 +92,7 @@ void main() {
     test('Running customDiscover tests', () {
       for (final activeHost in hostsWithOpenPort) {
         expectLater(
-          PortScannerFlutter.customDiscover(activeHost.address,
+          PortScannerService.instance.customDiscover(activeHost.address,
               portList: [port - 1, port, port + 1]),
           emits(isA<ActiveHost>()),
         );
@@ -102,7 +102,7 @@ void main() {
     test('Running customDiscover Async tests', () {
       for (final activeHost in hostsWithOpenPort) {
         expectLater(
-          PortScannerFlutter.customDiscover(
+          PortScannerService.instance.customDiscover(
             activeHost.address,
             portList: [port - 1, port, port + 1],
             async: true,
@@ -115,7 +115,7 @@ void main() {
     test('Running isOpen tests', () {
       for (final activeHost in hostsWithOpenPort) {
         expectLater(
-          PortScannerFlutter.isOpen(activeHost.address, port),
+          PortScannerService.instance.isOpen(activeHost.address, port),
           completion(
             isA<ActiveHost>().having(
               (p0) => p0.openPorts.contains(OpenPort(port)),


### PR DESCRIPTION
The code of this package should be based on the implementations of network_tools and override only the necessary parts that require flutter platform-specific override.

In order to achieve that I have changed the package to use inheritance of services, this will make development and code easier to maintain.

Another benefit is that users call the method exactly the same way as network tools

Old
network_tools:  `HostScanner.x();`
network_tools_flutter `HostScannerFlutter.x();`

New
network_tools:  `HostScannerService.instance.x();`
network_tools_flutter `HostScannerService.instance.x();`

To achieve that user needs to initialize the flutter package with this method `configureNetworkToolsFlutter` at the main function

Change:
`configureNetworkTools` --> `configureNetworkToolsFlutter`


This pr is ready but is blocked but based on https://github.com/osociety/network_tools/pull/183 pr to network_tools to work so it is currently blocked.

Fix: #38 

**This pr does not change the package logic.**
 